### PR TITLE
Fix and tests for incorrect mapping of nullable data types

### DIFF
--- a/Csg.Data.Sql.Tests/DbConvertTests.cs
+++ b/Csg.Data.Sql.Tests/DbConvertTests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using Csg.Data;
+using Csg.Data.Sql;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TestProject
+{
+    [TestClass]
+    public class DbConvertTests
+    {
+        [TestMethod]
+        public void Test_TypeToDbType()
+        {
+            Assert.AreEqual(System.Data.DbType.Boolean, DbConvert.TypeToDbType(typeof(bool)));
+            Assert.AreEqual(System.Data.DbType.Boolean, DbConvert.TypeToDbType(typeof(bool?)));
+            
+            Assert.AreEqual(System.Data.DbType.Byte, DbConvert.TypeToDbType(typeof(byte)));
+            Assert.AreEqual(System.Data.DbType.Byte, DbConvert.TypeToDbType(typeof(byte?)));
+            
+            Assert.AreEqual(System.Data.DbType.Int16, DbConvert.TypeToDbType(typeof(short)));
+            Assert.AreEqual(System.Data.DbType.Int16, DbConvert.TypeToDbType(typeof(short?)));
+
+            Assert.AreEqual(System.Data.DbType.Int32, DbConvert.TypeToDbType(typeof(int)));
+            Assert.AreEqual(System.Data.DbType.Int32, DbConvert.TypeToDbType(typeof(int?)));
+
+            Assert.AreEqual(System.Data.DbType.Int64, DbConvert.TypeToDbType(typeof(long)));
+            Assert.AreEqual(System.Data.DbType.Int64, DbConvert.TypeToDbType(typeof(long?)));
+
+            Assert.AreEqual(System.Data.DbType.Single, DbConvert.TypeToDbType(typeof(float)));
+            Assert.AreEqual(System.Data.DbType.Single, DbConvert.TypeToDbType(typeof(float?)));
+
+            Assert.AreEqual(System.Data.DbType.Double, DbConvert.TypeToDbType(typeof(double)));
+            Assert.AreEqual(System.Data.DbType.Double, DbConvert.TypeToDbType(typeof(double?)));
+
+            Assert.AreEqual(System.Data.DbType.Decimal, DbConvert.TypeToDbType(typeof(decimal)));
+            Assert.AreEqual(System.Data.DbType.Decimal, DbConvert.TypeToDbType(typeof(decimal?)));
+
+            Assert.AreEqual(System.Data.DbType.String, DbConvert.TypeToDbType(typeof(string)));
+            Assert.AreEqual(System.Data.DbType.String, DbConvert.TypeToDbType(typeof(string)));
+
+            Assert.AreEqual(System.Data.DbType.Guid, DbConvert.TypeToDbType(typeof(Guid)));
+            Assert.AreEqual(System.Data.DbType.Guid, DbConvert.TypeToDbType(typeof(Guid?)));
+
+            Assert.AreEqual(System.Data.DbType.DateTime2, DbConvert.TypeToDbType(typeof(DateTime)));
+            Assert.AreEqual(System.Data.DbType.DateTime2, DbConvert.TypeToDbType(typeof(DateTime?)));
+
+            Assert.AreEqual(System.Data.DbType.DateTimeOffset, DbConvert.TypeToDbType(typeof(DateTimeOffset)));
+            Assert.AreEqual(System.Data.DbType.DateTimeOffset, DbConvert.TypeToDbType(typeof(DateTimeOffset?)));
+
+            Assert.AreEqual(System.Data.DbType.Time, DbConvert.TypeToDbType(typeof(TimeSpan)));
+            Assert.AreEqual(System.Data.DbType.Time, DbConvert.TypeToDbType(typeof(TimeSpan?)));
+
+            Assert.AreEqual(System.Data.DbType.StringFixedLength, DbConvert.TypeToDbType(typeof(char)));
+            Assert.AreEqual(System.Data.DbType.StringFixedLength, DbConvert.TypeToDbType(typeof(char?)));
+
+            Assert.AreEqual(System.Data.DbType.Binary, DbConvert.TypeToDbType(typeof(byte[])));
+        }        
+
+        [TestMethod]
+        public void SqlCompareFilter_GetsCorrectType()
+        {
+            var filter1 = new SqlCompareFilter<bool>();
+            var filter2 = new SqlCompareFilter<bool?>();
+
+            Assert.AreEqual(DbType.Boolean, filter1.DataType);
+            Assert.AreEqual(DbType.Boolean, filter2.DataType);
+        }
+
+        [TestMethod]
+        public void SqlListFilter_GetsCorrectType()
+        {
+            var table = SqlTable.Create("foo");
+            var filter1 = new SqlListFilter<int>(table, "Foo", new List<int>());
+            var filter2 = new SqlListFilter<int?>(table, "Foo", new List<int?>());
+
+            Assert.AreEqual(DbType.Int32, filter1.DataType);
+            Assert.AreEqual(DbType.Int32, filter2.DataType);
+        }
+    }
+
+
+}
+
+
+

--- a/Csg.Data/DbConvert.cs
+++ b/Csg.Data/DbConvert.cs
@@ -144,10 +144,8 @@ namespace Csg.Data
         /// <returns></returns>
         public static System.Data.DbType TypeToDbType(Type type)
         {
-            if (type == typeof(Nullable<>))
-            {
-                type = type.GetGenericArguments()[0];
-            }
+            var underlyingType = Nullable.GetUnderlyingType(type);
+            type = underlyingType ?? type;
 
             if (type == typeof(byte)) return DbType.Byte;
             if (type == typeof(short)) return DbType.Int16;

--- a/Csg.Data/Sql/SqlCompareFilterT.cs
+++ b/Csg.Data/Sql/SqlCompareFilterT.cs
@@ -17,6 +17,7 @@ namespace Csg.Data.Sql
         public SqlCompareFilter()
         {
             this.EncodeValueAsLiteral = false;
+            this.DataType = DbConvert.TypeToDbType(typeof(TValue));
         }
 
         /// <summary>
@@ -30,8 +31,7 @@ namespace Csg.Data.Sql
         {
             this.Table = table;
             this.ColumnName = columnName;
-            this.Operator = @operator;
-            this.DataType = util.ConvertTypeCodeToDbType(Type.GetTypeCode(typeof(TValue)));
+            this.Operator = @operator;            
             this.Value = value;            
         }
 

--- a/Csg.Data/Sql/SqlListFilterT.cs
+++ b/Csg.Data/Sql/SqlListFilterT.cs
@@ -17,7 +17,7 @@ namespace Csg.Data.Sql
         /// <param name="table">The table source for the column</param>
         /// <param name="columnName">The table column to filter on.</param>
         /// <param name="values">The list of values to compare with.</param>
-        public SqlListFilter(ISqlTable table, string columnName, IEnumerable<T> values): base(table, columnName, util.ConvertTypeCodeToDbType(System.Type.GetTypeCode(typeof(T))), values)
+        public SqlListFilter(ISqlTable table, string columnName, IEnumerable<T> values): base(table, columnName, DbConvert.TypeToDbType(typeof(T)), values)
         {
         }
     }

--- a/Csg.Data/util.cs
+++ b/Csg.Data/util.cs
@@ -5,7 +5,6 @@ namespace Csg.Data
 {
     internal static class util
     {
-
         public static System.InvalidOperationException InvalidOperationException(string format, object arg0)
         {
             return new InvalidOperationException(string.Format(format, arg0));
@@ -15,11 +14,5 @@ namespace Csg.Data
         {
             return DbConvert.ConvertValue(value, dbType);
         }
-
-        public static DbType ConvertTypeCodeToDbType(TypeCode typeCode)
-        {
-            return DbConvert.TypeCodeToDbType(typeCode);
-        }
-
     }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="./build/sources.props" />
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.25" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.50" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All"/>
   </ItemGroup>
   <PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.404",
+    "rollForward": "latestMinor"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1",
+    "version": "3.1.0",
     "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.404",
+    "version": "3.1",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
Fixing a problem I noticed when trying to create filters with nullable types.

Before this fix, the following code generates a parameter with the incorrect DbType

```csharp
query = query.Where(x => x.FieldEquals<bool?>("Foo", true);
// generated parameter for Foo has DataType of DbType.AnsiString instead of DbType.Boolean
```