### PR TITLE
Fix issue where FieldMatch<T> doesn't use the generic type argument t…

### DIFF
--- a/Csg.Data.Sql.Tests/FluentAPITests.cs
+++ b/Csg.Data.Sql.Tests/FluentAPITests.cs
@@ -166,5 +166,26 @@ namespace TestProject
             Assert.AreEqual(test, stmt.CommandText, true);
         }
 
+        [TestMethod]
+        public void TestFieldMatchInfersCorrectDbTypeFromClrType()
+        {
+            var stmt = new MockConnection().QueryBuilder("dbo.Product")
+                .Where(x => x.FieldMatch("byte", SqlOperator.Equal, (byte)0))
+                .Where(x => x.FieldMatch("Int16", SqlOperator.Equal, (short)123))
+                .Where(x => x.FieldMatch("Int32", SqlOperator.Equal, 123))
+                .Where(x => x.FieldMatch("Int64", SqlOperator.Equal, (long)123))
+                .Where(x => x.FieldMatch("bool", SqlOperator.Equal, true))
+                .Where(x => x.FieldMatch("string", SqlOperator.Equal, "test123"))
+                .Render();
+
+            var plist = stmt.Parameters.ToList();
+            Assert.AreEqual(System.Data.DbType.Byte, plist[0].DbType);
+            Assert.AreEqual(System.Data.DbType.Int16, plist[1].DbType);
+            Assert.AreEqual(System.Data.DbType.Int32, plist[2].DbType);
+            Assert.AreEqual(System.Data.DbType.Int64, plist[3].DbType);
+            Assert.AreEqual(System.Data.DbType.Boolean, plist[4].DbType);
+            Assert.AreEqual(System.Data.DbType.String, plist[5].DbType);
+        }
+
     }
 }

--- a/Csg.Data/DbWhereClauseExtensions.cs
+++ b/Csg.Data/DbWhereClauseExtensions.cs
@@ -63,8 +63,7 @@ namespace Csg.Data
             {
                 where.AddFilter(new Csg.Data.Sql.SqlCompareFilter<TValue>(where.Root, fieldName, @operator, value)
                 {
-                    //TODO: Is AnsiString the right default?
-                    DataType = dbType.HasValue ? dbType.Value : DbType.AnsiString,
+                    DataType = dbType.HasValue ? dbType.Value : DbConvert.TypeToDbType(typeof(TValue)),
                     Size = size,
                 });
             }


### PR DESCRIPTION
This fixes an issue where using the fluent API FieldMatch<T> method without specifying the dbType parameter does not generate parameters of the expected type.

Before this fix, the below code would generate the correct WHERE clause, but the associated parameter's data type would be DbType.AnsiString, instead of the correct type of DbType.Int32.

```query.Where(x => x.FieldMatch("Foo", SqlOperator.NotEqual, 123))```

The fix uses  DbConvert.TypeToDbType to infer the correct DbType when the dbType parameter is not specified.

